### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1090,4 +1090,4 @@ MIT License.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cagostino/npcpy&type=Date)](https://star-history.com/#cagostino/npcpy&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cagostino/npcpy&type=Date)](https://star-history.dera.page/#cagostino/npcpy&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points it to a working alternative so the chart renders again.