### PR TITLE
docs: document OrcaRouter in the LLM provider summary

### DIFF
--- a/docs/guides/llm-responses.md
+++ b/docs/guides/llm-responses.md
@@ -195,6 +195,7 @@ AirLLM loads and processes model layers sequentially, allowing you to run models
 |----------|--------------|-------|
 | `ollama` | `llama3.2`, `gemma3:4b` | Local models, default provider |
 | `openai` | `gpt-4o`, `gpt-4o-mini` | Requires `OPENAI_API_KEY` |
+| `openai` | `orcarouter/auto` | [OrcaRouter](https://www.orcarouter.ai) gateway: set `api_url` to `https://api.orcarouter.ai/v1` with a `sk-orca-` key |
 | `anthropic` | `claude-sonnet-4` | Requires `ANTHROPIC_API_KEY` |
 | `gemini` | `gemini-2.0-flash` | Requires `GEMINI_API_KEY` |
 | `deepseek` | `deepseek-chat`, `deepseek-reasoner` | Requires `DEEPSEEK_API_KEY` |


### PR DESCRIPTION
Documents [OrcaRouter](https://www.orcarouter.ai) as an OpenAI-compatible gateway in the Provider Summary table of `docs/guides/llm-responses.md`, alongside the existing `openai` and `lmstudio` rows. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint: set `api_url` to `https://api.orcarouter.ai/v1`, use a key starting with `sk-orca-`, and pick the auto-routing `orcarouter/auto` model. Because the OpenAI-compatible provider is a thin base-URL swap, any npcpy pipeline that uses it also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents, with no application code changes.

I'm an engineer on the OrcaRouter team.
