### PR TITLE
fix(ml_funcs): require explicit trust to deserialize a joblib model

### DIFF
--- a/npcpy/ml_funcs.py
+++ b/npcpy/ml_funcs.py
@@ -667,16 +667,22 @@ def cross_validate(
 
 def serialize_model(model: Any, path: str, format: str = "joblib") -> None:
     """
-    Serialize model to file using safe formats (no pickle).
+    Serialize model to file.
 
     Args:
         model: The model to serialize
         path: File path to write to (required)
-        format: Serialization format - "joblib" (default) or "safetensors"
+        format: Serialization format - "joblib" (default, pickle-based) or
+            "safetensors" (PyTorch state_dict only)
 
     Raises:
         ImportError: If required library is not installed
         ValueError: If format is not supported for the model type
+
+    Note:
+        "joblib" uses joblib.dump, which pickles the model. Load a ".joblib"
+        file back with deserialize_model(..., trust_source=True) only from a
+        source you trust; see deserialize_model for why.
     """
     if format == "safetensors":
         from safetensors.torch import save_file
@@ -690,20 +696,29 @@ def serialize_model(model: Any, path: str, format: str = "joblib") -> None:
     else:
         raise ValueError(f"Unsupported format: {format}. Use 'joblib' or 'safetensors'.")
 
-def deserialize_model(path: str, format: str = "auto") -> Any:
+def deserialize_model(path: str, format: str = "auto", trust_source: bool = False) -> Any:
     """
-    Deserialize model from file using safe formats (no pickle).
+    Deserialize model from file.
 
     Args:
         path: File path to load from
         format: "auto" (detect from extension), "joblib", or "safetensors"
+        trust_source: Must be True to load a "joblib" file. joblib.load is a
+            thin wrapper over pickle.load and can execute arbitrary Python
+            code embedded in the file (per joblib's own docs: "joblib.load
+            relies on the pickle module and can therefore execute arbitrary
+            Python code. It should therefore never be used to load files
+            from untrusted sources."). Only pass trust_source=True for a file
+            you produced yourself or otherwise trust. "safetensors" carries
+            no such risk and does not need the flag.
 
     Returns:
         The deserialized model
 
     Raises:
         ImportError: If required library is not installed
-        ValueError: If format cannot be determined
+        ValueError: If format cannot be determined, or a "joblib" file is
+            loaded without trust_source=True
     """
     if format == "auto":
         if path.endswith('.safetensors'):
@@ -717,6 +732,14 @@ def deserialize_model(path: str, format: str = "auto") -> Any:
         from safetensors.torch import load_file
         return load_file(path)
     elif format == "joblib":
+        if not trust_source:
+            raise ValueError(
+                "Refusing to load a 'joblib' file without trust_source=True: "
+                "joblib.load executes arbitrary Python code embedded in the "
+                "file. Pass deserialize_model(path, trust_source=True) only "
+                "after confirming you trust the source, or re-save the model "
+                "with format='safetensors' if it doesn't need trust."
+            )
         import joblib
         return joblib.load(path)
     else:

--- a/npcpy/ml_funcs.py
+++ b/npcpy/ml_funcs.py
@@ -734,11 +734,11 @@ def deserialize_model(path: str, format: str = "auto", trust_source: bool = Fals
     elif format == "joblib":
         if not trust_source:
             raise ValueError(
-                "Refusing to load a 'joblib' file without trust_source=True: "
-                "joblib.load executes arbitrary Python code embedded in the "
-                "file. Pass deserialize_model(path, trust_source=True) only "
-                "after confirming you trust the source, or re-save the model "
-                "with format='safetensors' if it doesn't need trust."
+                """Refusing to load a 'joblib' file without trust_source=True:
+                joblib.load executes arbitrary Python code embedded in the
+                file. Pass deserialize_model(path, trust_source=True) only
+                after confirming you trust the source, or re-save the model
+                with format='safetensors' if it doesn't need trust."""
             )
         import joblib
         return joblib.load(path)

--- a/tests/test_ml_funcs.py
+++ b/tests/test_ml_funcs.py
@@ -226,7 +226,7 @@ class TestModelSerialization:
         try:
             model_path = os.path.join(temp_dir, "model.joblib")
             serialize_model(model, model_path, format="joblib")
-            loaded = deserialize_model(model_path)
+            loaded = deserialize_model(model_path, trust_source=True)
 
             assert loaded is not None
             # Check predictions match
@@ -253,12 +253,44 @@ class TestModelSerialization:
         try:
             model_path = os.path.join(temp_dir, "model.joblib")
             serialize_model(model, model_path)  # default format
-            loaded = deserialize_model(model_path, format="auto")
+            loaded = deserialize_model(model_path, format="auto", trust_source=True)
 
             assert loaded is not None
             orig_pred = model.predict([[4]])
             loaded_pred = loaded.predict([[4]])
             assert np.allclose(orig_pred, loaded_pred)
+        finally:
+            import shutil
+            shutil.rmtree(temp_dir)
+
+    def test_deserialize_model_joblib_requires_trust_source(self):
+        """A 'joblib' file must not load without trust_source=True.
+
+        joblib.load is a pickle wrapper: it runs whatever __reduce__ the file
+        embeds. deserialize_model must refuse by default rather than execute
+        an arbitrary callable found in an untrusted file.
+        """
+        pytest.importorskip("joblib")
+        import joblib
+        from npcpy.ml_funcs import deserialize_model
+
+        class ArbitraryCallable:
+            def __reduce__(self):
+                # Any callable+args would run here; os.getpid is inert and
+                # only serves to prove the reduce path executes.
+                return (os.getpid, ())
+
+        temp_dir = tempfile.mkdtemp()
+        try:
+            model_path = os.path.join(temp_dir, "untrusted.joblib")
+            joblib.dump(ArbitraryCallable(), model_path)
+
+            with pytest.raises(ValueError, match="trust_source"):
+                deserialize_model(model_path, format="joblib")
+
+            # Explicit opt-in still works (the mechanism itself is unchanged).
+            result = deserialize_model(model_path, format="joblib", trust_source=True)
+            assert result == os.getpid()
         finally:
             import shutil
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
## Root cause

`deserialize_model`'s default `format="joblib"` calls `joblib.load(path)`. `joblib.load` is a thin wrapper over `pickle.load`, so it executes whatever callable a `.joblib` file's `__reduce__` embeds; joblib's own docs warn it "should therefore never be used to load files from untrusted sources." The docstrings on both `serialize_model` and `deserialize_model` claimed "safe formats (no pickle)", but `"joblib"` is the default format for both functions, so the exact issue this closes was relabeled rather than fixed. I confirmed against current `main` that calling `deserialize_model(path, format="joblib")` on a crafted `.joblib` file runs an attacker-chosen callable.

## Fix

`deserialize_model` now takes `trust_source: bool = False` and refuses to load a `"joblib"` file unless it is `True`, raising a `ValueError` that explains why and points at `format="safetensors"` as the no-risk alternative. `safetensors` loading is unchanged; it never touches pickle. Docstrings on both functions now describe `"joblib"` accurately instead of calling it safe.

## Verification

- New test `test_deserialize_model_joblib_requires_trust_source`: fails on `main` (no `trust_source` param exists, so the crafted file loads and the callable runs) and passes on this branch (raises `ValueError`, and explicit `trust_source=True` still loads).
- `pytest tests/test_ml_funcs.py` (the file CI runs for this module): 20/20 pass on Python 3.10, 3.11, and 3.12.
- Updated the two existing round-trip tests to pass `trust_source=True`, since they load a file they just wrote themselves in the same test.
- I did not audit other `joblib.load` call sites in the repo; `npcpy/serve.py`'s `/api/ml/predict` also calls it, but only ever on files written by this app's own `/api/ml/train` endpoint to a fixed server directory, a different trust boundary from this issue's file-path API.

Fixes #198
