### PR TITLE
fix(serve): pass required model/provider to get_embeddings in KG routes

### DIFF
--- a/npcpy/serve.py
+++ b/npcpy/serve.py
@@ -838,7 +838,7 @@ def embed_kg_facts():
         for i in range(0, len(statements), batch_size):
             batch = statements[i:i + batch_size]
             try:
-                embeddings = get_embeddings(batch)
+                embeddings = get_embeddings(batch, "nomic-embed-text", "ollama")
             except Exception as e:
                 print(f"Failed to get embeddings for batch {i}: {e}")
                 continue
@@ -884,7 +884,7 @@ def search_kg_semantic():
         if not chroma_db_path:
             return jsonify({"error": "CHROMA_DB_PATH not configured", "facts": [], "query": q}), 500
         try:
-            query_embedding = get_embeddings([q])[0]
+            query_embedding = get_embeddings([q], "nomic-embed-text", "ollama")[0]
         except Exception as e:
             return jsonify({
                 "error": f"Failed to generate embedding: {str(e)}",


### PR DESCRIPTION
### Problem

`get_embeddings` in `npcpy/gen/embeddings.py` requires `model` and `provider` — they have no defaults:

```python
def get_embeddings(
    texts: List[str],
    model: str,
    provider: str,
) -> List[List[float]]:
```

Two Flask routes in `serve.py` call it with only `texts`:

- `/api/kg/embed` (`embed_kg_facts`): `embeddings = get_embeddings(batch)`
- `/api/kg/search/semantic` (`search_kg_semantic`): `query_embedding = get_embeddings([q])[0]`

Both raise `TypeError: get_embeddings() missing 2 required positional arguments: 'model' and 'provider'` on the first call. The surrounding `try/except Exception` swallows it, so the failure is silent:

- `/api/kg/embed` catches per-batch, `continue`s every batch, and always returns `"Embedded 0 facts"`.
- `/api/kg/search/semantic` returns `{"error": "Failed to generate embedding: ..."}` for every query.

So knowledge-graph embedding and semantic search are non-functional through the server.

### Fix

Pass the same embedding defaults the rest of the codebase already uses — `nomic-embed-text` / `ollama` (see `npcpy/memory/knowledge_graph.py`, e.g. `_get_similar_by_embedding(..., model='nomic-embed-text', provider='ollama')` and the `embedding_model or 'nomic-embed-text'` / `embedding_provider or 'ollama'` fallbacks).

```python
embeddings = get_embeddings(batch, "nomic-embed-text", "ollama")
query_embedding = get_embeddings([q], "nomic-embed-text", "ollama")[0]
```

Two-line change; no behavior change beyond the calls now succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
